### PR TITLE
Fix handle_down error message

### DIFF
--- a/bindings/erlang/src/vanillae_man.erl
+++ b/bindings/erlang/src/vanillae_man.erl
@@ -189,11 +189,11 @@ handle_down(PID, Mon, Info, State = #s{fetchers = Fetchers}) ->
         {value, #fetcher{time = Time, node = Node, from = From, req = R}, Remaining} ->
             TS = calendar:system_time_to_rfc3339(Time, [{unit, nanosecond}]),
             Format =
-                "ERROR ~s: Fetcher process ~130p exited while making request to ~130p~n"
+                "ERROR ~ts: Fetcher process ~130tp exited while making request to ~130tp~n"
                 "Exit reason:~n"
-                "~p~n"
+                "~tp~n"
                 "Request contents:~n"
-                "~p~n~n",
+                "~tp~n~n",
             Formatted = io_lib:format(Format, [TS, PID, Node, Info, R]),
             Message = unicode:characters_to_list(Formatted),
             ok = gen_server:reply(From, {error, Message}),

--- a/bindings/erlang/src/vanillae_man.erl
+++ b/bindings/erlang/src/vanillae_man.erl
@@ -189,9 +189,11 @@ handle_down(PID, Mon, Info, State = #s{fetchers = Fetchers}) ->
         {value, #fetcher{time = Time, node = Node, from = From, req = R}, Remaining} ->
             TS = calendar:system_time_to_rfc3339(Time, [{unit, nanosecond}]),
             Format =
-                "ERROR ~s: Fetcher process ~p making request to ~p exited with ~p~n"
-                "Request contents:~n~n"
-                "~s",
+                "ERROR ~s: Fetcher process ~130p exited while making request to ~130p~n"
+                "Exit reason:~n"
+                "~p~n"
+                "Request contents:~n"
+                "~p~n~n",
             Formatted = io_lib:format(Format, [TS, PID, Node, Info, R]),
             Message = unicode:characters_to_list(Formatted),
             ok = gen_server:reply(From, {error, Message}),


### PR DESCRIPTION
It was printing a tuple with `~s`, which caused handle_down to crash, and then when that was fixed it also tried to pretty print a complex term more than a hundred columns into a line, leading to a message that was obscurely hockey-stick-shaped even for Erlang. Both of these are fixed now.

Feel free to touch up the style some more if e.g. my double newlines at the end of the message are bad style.